### PR TITLE
Update EmptyOrganizationalUnits.ps1

### DIFF
--- a/Private/SourcesDomain/EmptyOrganizationalUnits.ps1
+++ b/Private/SourcesDomain/EmptyOrganizationalUnits.ps1
@@ -5,7 +5,7 @@
         Data           = {
             $OrganizationalUnits = Get-ADOrganizationalUnit -Filter * -Properties distinguishedname -Server $Domain | Select-Object -ExpandProperty distinguishedname
 
-            $AllUsedOU = Get-ADObject -Filter "ObjectClass -eq 'user' -or ObjectClass -eq 'computer' -or ObjectClass -eq 'group'" -Server $Domain | `
+            $AllUsedOU = Get-ADObject -Filter "ObjectClass -eq 'user' -or ObjectClass -eq 'computer' -or ObjectClass -eq 'group' -or ObjectClass -eq 'contact'" -Server $Domain | `
                 Where-Object { ($_.DistinguishedName -notlike '*LostAndFound*') -and ($_.DistinguishedName -match 'OU=(.*)') } | `
                 ForEach-Object { $matches[0] } | `
                 Select-Object -Unique


### PR DESCRIPTION
Currently, the " Orphaned/Empty Organizational Units" test fails if an OU only has contacts. This change adds the "contact" object class to the empty ou search.