### PR TITLE
Update DNSScavengingForPrimaryDNSServer.ps1

### DIFF
--- a/Private/SourcesDomain/DNSScavengingForPrimaryDNSServer.ps1
+++ b/Private/SourcesDomain/DNSScavengingForPrimaryDNSServer.ps1
@@ -66,7 +66,7 @@
                 # this date should be the same as in Scavending Interval
                 Property      = 'LastScavengeTime'
                 # we need to use string which will be converted to ScriptBlock later on due to configuration export to JSON
-                ExpectedValue = '(Get-Date).AddDays(-7)'
+                ExpectedValue = '(Get-Date).AddDays(7)'
                 OperationType = 'lt'
             }
         }

--- a/Private/SourcesDomain/DNSScavengingForPrimaryDNSServer.ps1
+++ b/Private/SourcesDomain/DNSScavengingForPrimaryDNSServer.ps1
@@ -66,8 +66,8 @@
                 # this date should be the same as in Scavending Interval
                 Property      = 'LastScavengeTime'
                 # we need to use string which will be converted to ScriptBlock later on due to configuration export to JSON
-                ExpectedValue = '(Get-Date).AddDays(7)'
-                OperationType = 'lt'
+                ExpectedValue = '(Get-Date).AddDays(-7)'
+                OperationType = 'gt'
             }
         }
     }


### PR DESCRIPTION
Change DNS last scavenge time to be less than seven days _from now_, instead of more than seven days _ago_. Test current fails if scavenging occurred too recently.