### PR TITLE
Fixing legacy ADM files check

### DIFF
--- a/Private/SourcesDomain/GroupPolicyADM.ps1
+++ b/Private/SourcesDomain/GroupPolicyADM.ps1
@@ -4,7 +4,7 @@
         Name           = "Group Policy Legacy ADM Files"
         Data           = {
             #$Domain = 'ad.evotec.xyz'
-            Get-ChildItem -Path "\\$Domain\SYSVOL\$Domain\policies" -ErrorAction Stop -Recurse -Filter '*.adm' | Select-Object Name, FullName, CreationTime, LastWriteTime, Attributes
+            Get-ChildItem -Path "\\$Domain\SYSVOL\$Domain\policies" -ErrorAction Stop -Recurse -Include '*.adm' | Select-Object Name, FullName, CreationTime, LastWriteTime, Attributes
         }
         ExpectedOutput = $false
         Details        = [ordered] @{


### PR DESCRIPTION
Filter property included non-legacy files, changed to include so the test works as intended.