### PR TITLE
GroupPolicyPermission.ps1 Unknown False to True

### DIFF
--- a/Private/SourcesDomain/GroupPolicyPermission.ps1
+++ b/Private/SourcesDomain/GroupPolicyPermission.ps1
@@ -55,7 +55,7 @@
             Parameters = @{
                 ExpectedCount = 0
                 OperationType = 'eq'
-                WhereObject   = { $_.Unknown -eq $false }
+                WhereObject   = { $_.Unknown -eq $true }
             }
         }
     }


### PR DESCRIPTION
Unknown eq True is the bad case. We only want to fail the test if results are returned with Unknown eq True. Looks like this was the original intent based on commented out line 135. Currently the test fails if no GPOs have unknown permissions.