### PR TITLE
Limit Resolve-DnsName results to A records in the Answer section

### DIFF
--- a/Private/SourcesDomainControllers/DNSResolveExternal.ps1
+++ b/Private/SourcesDomainControllers/DNSResolveExternal.ps1
@@ -5,7 +5,7 @@
         Name           = "Resolves external DNS queries"
         Data           = {
             $Output = Invoke-Command -ComputerName $DomainController -ErrorAction Stop {
-                Resolve-DnsName -Name 'testimo-check.evotec.xyz' -ErrorAction SilentlyContinue
+                Resolve-DnsName -Name 'testimo-check.evotec.xyz' -ErrorAction SilentlyContinue | Where-Object { $_.Section -eq 'Answer -and $_.Type -eq 'A' }
             }
             $Output
         }


### PR DESCRIPTION
This change addresses issue #132 and adds a filter to the Resolve-DnsName results so they only include A records from the Answer section and get rid of false test failures for the Authority NS records and Additional A records.