### PR TITLE
Fix PowerShell 2.0 detection

### DIFF
--- a/Private/SourcesDomainControllers/WindowsFeaturesOptional.ps1
+++ b/Private/SourcesDomainControllers/WindowsFeaturesOptional.ps1
@@ -6,7 +6,7 @@
         Name           = "Windows Features Optional"
         Data           = {
             $Output = Invoke-Command -ComputerName $DomainController -ErrorAction Stop {
-                Get-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2 | Select-Object -Property DisplayName, Description, RestartRequired, FeatureName
+                Get-WindowsOptionalFeature -Online -FeatureName MicrosoftWindowsPowerShellV2 | Select-Object -Property DisplayName, Description, RestartRequired, FeatureName, State
             }
             $Output
         }


### PR DESCRIPTION
Trying to compare to a property that isn't returned.