### PR TITLE
Fix DomainGroupPolicySysvol

### DIFF
--- a/Private/SourcesDomain/GroupPolicySysvol.ps1
+++ b/Private/SourcesDomain/GroupPolicySysvol.ps1
@@ -5,7 +5,7 @@
     Source = @{
         Name           = "GPO: Sysvol folder existance"
         Data           = {
-            Get-GPOZaurrSysvol -Forest $ForestName -IncludeDomains $Domain
+            Get-GPOZaurrBroken -Forest $ForestName -IncludeDomains $Domain
         }
         Details        = [ordered] @{
             Area        = 'Security'
@@ -25,7 +25,7 @@
             Enable     = $true
             Name       = 'GPO: Files on SYSVOL are not Orphaned'
             Parameters = @{
-                WhereObject    = { $_.SysvolStatus -ne 'Exists' -or $_.Status -ne 'Exists' }
+                WhereObject    = { $_.SysvolStatus -ne 'Exists' -and $_.Status -ne 'Exists' }
                 ExpectedResult = $false # this tests things in bundle rather then per object of array
             }
 

--- a/Private/SourcesDomainControllers/GroupPolicySYSVOLDC.ps1
+++ b/Private/SourcesDomainControllers/GroupPolicySYSVOLDC.ps1
@@ -5,7 +5,7 @@
     Source = @{
         Name           = "Group Policy SYSVOL Verification"
         Data           = {
-            Get-GPOZaurrSysvol -IncludeDomains $Domain -IncludeDomainControllers $DomainController -VerifyDomainControllers | Where-Object { $_.Status -ne 'Exists' }
+            Get-GPOZaurrBroken -IncludeDomains $Domain -IncludeDomainControllers $DomainController -VerifyDomainControllers | Where-Object { $_.Status -ne 'Exists' }
         }
         Details        = [ordered] @{
             Area        = ''


### PR DESCRIPTION
The WhereObject comparison always returns a value since the Get-GPOZaurrBroken only returns SysvolStatus or Status as of 15538e8559acaa2aa8fc414b9dac2c88de2833df.

Also updated the command to match the new name as of version 0.0.64.