### PR TITLE
Replaced TCIP typo with TCPIP

### DIFF
--- a/Example/Configuration/TestimoConfiguration.json
+++ b/Example/Configuration/TestimoConfiguration.json
@@ -2080,7 +2080,7 @@
                                                  "ExpectedOutput":  true
                                              },
                                   "Tests":  {
-                                                "NETBIOSOverTCIP":  {
+                                                "NETBIOSOverTCPIP":  {
                                                                         "Enable":  true,
                                                                         "Parameters":  {
                                                                                            "Property":  "NetBIOSOverTCPIP",

--- a/Private/SourcesDomainControllers/NetworkCardSettings.ps1
+++ b/Private/SourcesDomainControllers/NetworkCardSettings.ps1
@@ -21,9 +21,9 @@
         ExpectedOutput = $true
     }
     Tests  = [ordered] @{
-        NETBIOSOverTCIP        = @{
+        NETBIOSOverTCPIP        = @{
             Enable     = $true
-            Name       = 'NetBIOS over TCIP should be disabled.'
+            Name       = 'NetBIOS over TCPIP should be disabled.'
             Parameters = @{
                 Property      = 'NetBIOSOverTCPIP'
                 ExpectedValue = 'Disabled'


### PR DESCRIPTION
Fixed a typo, replacing all instances of "TCIP" with "TCPIP."