### PR TITLE
Fixed Importance value for NetBIOSOverTCPIP from 90 to 9.

### DIFF
--- a/Private/SourcesDomainControllers/NetworkCardSettings.ps1
+++ b/Private/SourcesDomainControllers/NetworkCardSettings.ps1
@@ -33,7 +33,7 @@
                 Area        = 'Connectivity'
                 Category    = 'Legacy Protocols'
                 Severity    = 'Critical'
-                Importance  = 90 # 100 is top
+                Importance  = 9 # 10 is top
                 Description = @'
                 NetBIOS over TCP/IP is a networking protocol that allows legacy computer applications relying on the NetBIOS to be used on modern TCP/IP networks.
                 Enabling NetBios might help an attackers access shared directories, files and also gain sensitive information such as computer name, domain, or workgroup.


### PR DESCRIPTION
Fixed Importance value for NetBIOSOverTCPIP from 90 to 9 and updated the inline comment.