### PR TITLE
Fixed Importance for Default SMB Shares Permissions

### DIFF
--- a/Private/SourcesDomainControllers/SMBSharesPermissions.ps1
+++ b/Private/SourcesDomainControllers/SMBSharesPermissions.ps1
@@ -11,7 +11,7 @@
             Area        = 'Security'
             Description = "SMB Shares for Sysvol and Netlogon should be at their defaults. That means 2 permissions for Netlogon and 3 for SysVol."
             Resolution  = 'Add/Remove unnecessary permissions.'
-            Importance  = 20
+            Importance  = 3
             Resources   = @(
 
             )


### PR DESCRIPTION
Fixed Importance value for Default SMB Shares Permissions from `20` (Low in StatusTranslation) to `3` (Low in Importance labels).